### PR TITLE
Use --enable-build-raft for dqlite package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,8 @@ Maintainer: Cole Miller <cole.miller@canonical.com>
 Build-Depends: debhelper (>= 10),
                pkgconf,
                libsqlite3-dev,
-               libuv1-dev
+               libuv1-dev,
+               liblz4-dev
 Homepage: https://github.com/canonical/dqlite
 Standards-Version: 4.5.1
 Rules-Requires-Root: no
@@ -24,7 +25,11 @@ Description: Distributed sqlite database using Raft - library
 Package: libdqlite-dev
 Section: libdevel
 Architecture: any
-Depends: libdqlite0 (= ${binary:Version}), ${misc:Depends}, libuv1-dev, libsqlite3-dev
+Depends: libdqlite0 (= ${binary:Version}),
+         ${misc:Depends},
+         libsqlite3-dev,
+         libuv1-dev,
+         liblz4-dev
 Multi-Arch: same
 Description: Distributed sqlite database using Raft - library
  libdqlite is a sqlite and Raft based distributed database.

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,6 @@ Priority: optional
 Maintainer: Mathieu Borderé <mathieu.bordere@canonical.com>
 Build-Depends: debhelper (>= 10),
                pkg-config,
-               libraft-canonical-dev,
                libsqlite3-dev,
                libuv1-dev
 Homepage: https://github.com/canonical/dqlite
@@ -25,7 +24,7 @@ Description: Distributed sqlite database using Raft - library
 Package: libdqlite-dev
 Section: libdevel
 Architecture: any
-Depends: libdqlite0 (= ${binary:Version}), ${misc:Depends}, libraft-canonical-dev, libuv1-dev, libsqlite3-dev
+Depends: libdqlite0 (= ${binary:Version}), ${misc:Depends}, libuv1-dev, libsqlite3-dev
 Multi-Arch: same
 Description: Distributed sqlite database using Raft - library
  libdqlite is a sqlite and Raft based distributed database.

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: devel
 Priority: optional
 Maintainer: Cole Miller <cole.miller@canonical.com>
 Build-Depends: debhelper (>= 10),
-               pkg-config,
+               pkgconf,
                libsqlite3-dev,
                libuv1-dev
 Homepage: https://github.com/canonical/dqlite

--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: dqlite
 Section: devel
 Priority: optional
-Maintainer: Mathieu Borderé <mathieu.bordere@canonical.com>
+Maintainer: Cole Miller <cole.miller@canonical.com>
 Build-Depends: debhelper (>= 10),
                pkg-config,
                libsqlite3-dev,

--- a/debian/rules
+++ b/debian/rules
@@ -15,3 +15,6 @@ export LIBRAFT_TRACE=1
 
 %:
 	dh $@ --with autoreconf
+
+override_dh_auto_configure:
+	dh_auto_configure -- --enable-build-raft


### PR DESCRIPTION
Signed-off-by: Cole Miller <cole.miller@canonical.com>