### PR TITLE
debian/control: depends on Go 1.23 or newer

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Cole Miller <cole.miller@canonical.com>
 Build-Depends: debhelper (>= 10),
                dh-golang,
-               golang-go,
+               golang-go (>= 1.23.1-1) | golang-1.23-go,
                pkg-config,
                libdqlite-dev
 Homepage: https://github.com/canonical/go-dqlite


### PR DESCRIPTION
Post release, Jammy+ saw the addition of `golang-1.23-go` along with multiple other versions.