### PR TITLE
chore: change maintaner

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: dqlite
 Section: devel
 Priority: optional
-Maintainer: Cole Miller <cole.miller@canonical.com>
+Maintainer: Marco Manino <marco.manino@canonical.com>
 Build-Depends: debhelper (>= 10),
                pkgconf,
                libsqlite3-dev,


### PR DESCRIPTION
This PR removes Cole as a maintainer as he is not part of Canonical anymore. I take the role as maintainer instead.