### PR TITLE
debian/control: depends on Go 1.22 or newer

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Cole Miller <cole.miller@canonical.com>
 Build-Depends: debhelper (>= 10),
                dh-golang,
-               golang-go,
+               golang-go (>= 1.22.2-2) | golang-1.22-go,
                pkg-config,
                libdqlite-dev
 Homepage: https://github.com/canonical/go-dqlite


### PR DESCRIPTION
Post release, Focal saw the addition of `golang-1.22-go` along with multiple other versions.

An alternative to #10 that remains compatible with Focal/20.04 and up.